### PR TITLE
more specific name for banner_text in JS to avoid clashing with other banners

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -27,7 +27,7 @@ class ExternalModule extends AbstractExternalModule {
         $banner_css = $this->fallbackParam('banner_css');
 
         echo "<style> #project-overlay-banner { " . $banner_css . " } </style>";
-        echo "<script type='text/javascript'>var banner_text = $banner_text;</script>";
+        echo "<script type='text/javascript'>var project_overlay_banner_text = $banner_text;</script>";
     }
 
     protected function fallbackParam($param_name, $param_default = "") {

--- a/js/banner_inject.js
+++ b/js/banner_inject.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-    $("body").prepend(`<div id='project-overlay-banner'> ${banner_text}</div>`);
+    $("body").prepend(`<div id='project-overlay-banner'> ${project_overlay_banner_text}</div>`);
 
     $("#project-overlay-banner").click(function() {
         $(this).hide();


### PR DESCRIPTION
Same change made to [Data Driven Project Banner](https://github.com/ctsit/data_driven_project_banner/pull/10/commits/93685c2871aff4abb5a75be34d7fc05c84700c54) in case other modules use the variable `banner_text` in their JavaScript.